### PR TITLE
chore: Remove "flowchart" language tag from code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Make sure you put it before other plugins (especially those that work with `code
 ### Usage in Markdown
 
 <pre>
-```flowchart
+```
 st=>start: Start:>http://www.google.com[blank]
 e=>end:>http://www.google.com
 op1=>operation: My Operation


### PR DESCRIPTION
This is to silence prism highlighter warnings -- `flowchart` is not on the list of [officially supported language tags](https://prismjs.com/#languages-list). Thanks"